### PR TITLE
Start mysql as same user on host

### DIFF
--- a/bin/build_nzedb
+++ b/bin/build_nzedb
@@ -1,2 +1,2 @@
 #!/bin/bash
-./venv/bin/docker-compose build --pull --force-rm "$@"
+venv/bin/docker-compose build --pull --force-rm "$@"

--- a/bin/setup_data_dir
+++ b/bin/setup_data_dir
@@ -23,5 +23,9 @@ touch data/log/nginx-access.log
 touch data/log/nginx-error.log
 touch data/log/php_errors.log
 touch data/log/php-fpm.log
+cat << EOF > data/mysql_user
+PUID=$(id --user)
+PGID=$(id --group)
+EOF
 chmod -R 777 data
 echo Done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - $PWD/data/var_lib_mysql:/var/lib/mysql
       - $PWD/data/etc_mysql_conf.d:/etc/mysql/conf.d
+      - $PWD/data/mysql_user:/mysql_user
     environment:
       - MYSQL_ROOT_PASSWORD=nzedb
       - MYSQL_DATABASE=nzedb

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -7,5 +7,6 @@ RUN sed -i -r 's/port.*$/port = 3306'/ /etc/mysql/my.cnf
 
 # To avoid mysql whining about this variable
 ENV TERM dumb 
-
+COPY moduser-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["moduser-entrypoint.sh"]
 CMD ["mysqld"]

--- a/mariadb/moduser-entrypoint.sh
+++ b/mariadb/moduser-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Allow changing id of mysql user and group because the hardcoded
+# id in the mysql image is a PITA with host volumes (having to use sudo
+# to remove files, etc).
+if [ -e "/mysql_user" ]; then
+  source /mysql_user
+
+  if ! id --user $PUID; then 
+    echo "Changing mysql user to uid $PUID"
+    usermod --uid $PUID mysql
+  fi
+
+  if ! id --group $PGID;  then
+    echo "Changing mysql group to gid $PGID"
+    groupmod --gid $PGID mysql
+  fi
+
+fi
+
+source /docker-entrypoint.sh
+


### PR DESCRIPTION
The mysql image has the mysql user and group id set to 999. However, the root user owns the files created in `$PWD/data/var_lib_mysql`.  This makes it difficult to manage the files on the host since sudo is necessary to reset the state of the acceptance test. All files that mysql writes to the mounted host volume at `$PWD/data` should be as the host user, not root.